### PR TITLE
pkgdown requires actual repo url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Imports:
 Depends: 
     R (>= 2.10)
 LazyData: true
-URL: https://john-b-edwards.github.io/cbbreadr/
+URL: https://github.com/john-b-edwards/cbbreadr,
+    https://john-b-edwards.github.io/cbbreadr/
 Suggests: 
     knitr,
     rmarkdown


### PR DESCRIPTION
to be able to create source links

For more info, see https://pkgdown.r-lib.org/reference/build_site.html?q=repo#source-repository