### PR TITLE
use actual input and catch non date inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cbbreadr
 Title: Quickly Access College Basketball Data
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: 
     person("John", "Edwards", , "edwards1860@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8533-7504"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,10 +21,11 @@ RELEASE_URL <- "https://github.com/john-b-edwards/cbbd-data/releases/download"
 #'
 #' @export
 most_recent_season <- function(date = Sys.Date()) {
-  if (as.integer(format(Sys.Date(), "%m")) < 10) {
-    return(as.integer(format(Sys.Date(), "%Y")))
+  date <- as.Date(date)
+  if (as.integer(format(date, "%m")) < 10) {
+    return(as.integer(format(date, "%Y")))
   } else {
-    return(as.integer(format(Sys.Date(), "%Y")) + 1)
+    return(as.integer(format(date, "%Y")) + 1)
   }
 }
 


### PR DESCRIPTION
`most_recent_season()` didn't use the user input and instead worked with Sys.Date only

<img width="484" height="243" alt="image" src="https://github.com/user-attachments/assets/9b67092c-2df9-4481-8feb-b648653eabc9" />

This has now been fixed, and it works as intended. I would add a test but you didn't set up tests yet and I don't want to make your package or this PR too complicated.

Also, the package requires re-documentation to actually document all the data. 